### PR TITLE
Removed bitbucket from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Welcome to the home of *plantecophys*, an R package that bundles a number of tools to analyze and model leaf gas exchange data.
 
-[Please report bugs or suggest features here](https://bitbucket.org/remkoduursma/plantecophys/issues?status=new&status=open).
-
 
 
 ### Contents
@@ -46,7 +44,7 @@ To install the development version, use the following command. Windows users mus
 
 ```
 library(devtools)
-install_bitbucket("remkoduursma/plantecophys")
+install_github("remkoduursma/plantecophys")
 ```
 
 


### PR DESCRIPTION
Hi,

Since you announced to close down your repo on bitbucket, I removed the parts of the README.md mentioning them (the link and changed `install_bitbucket` to `install_github` for the `devtool` section).